### PR TITLE
[docs] add Q&A: undefined reference to 'cbrt'

### DIFF
--- a/docs/faq/installation.md
+++ b/docs/faq/installation.md
@@ -70,3 +70,18 @@ cargo build --release -F ffi
 
 Please refer to [Library Size Optimization](../further_readings/minimizing_size/)
 
+
+## How to Fix "undefined reference to 'cbrt'" When Linking to a C/C++ Project?
+
+The "undefined reference to 'cbrt'" error occurs because the cbrt function is part of the math library (libm), which needs to be explicitly linked.
+
+For GCC/G++/Clang/Clang++ compilers, you can resolve this by adding the -lm option. If you are using CMake, include the following in your CMakeLists.txt:
+
+```
+target_link_libraries(
+  this_is_your_lib_name 
+  # Add other libraries if needed
+  tquic
+  m
+)
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq/installation.md
@@ -68,3 +68,17 @@ cargo build --release -F ffi
 
 请参考[移动端库文件大小优化](../further_readings/minimizing_size/)
 
+
+## 链接到 C/C++ 项目时，提示 undefined reference cbrt
+
+cbrt 函数是 libm 库的导出函数，开发者在链接需要手动链接 libm 库。对于 GCC/G++/Clang/Clang++ 编译器，尝试使用 -lm 编译选项。如果使用 CMake，尝试添加 
+
+```
+target_link_library(
+  this_is_your_lib_name 
+  # 忽略其它链接库名
+  tquic
+  m
+)
+
+```


### PR DESCRIPTION
The cbrt function is part of the math library (libm), which needs to be explicitly linked.

Resolve discussions #370.