### PR TITLE
Fixed the documentation in Example Tools

### DIFF
--- a/docs/getting_started/demo.md
+++ b/docs/getting_started/demo.md
@@ -15,7 +15,7 @@ The example tools are built by adding an option `--all` to the `cargo build` com
 
 ### Run the quic server
 ```bash
-./tquic_server -c cert.crt -k cert.key -l 127.0.0.1:8443
+./tquic_server -c ../../src/tls/testdata/cert.crt -k ../../src/tls/testdata/cert.key -l 127.0.0.1:8443 
 ```
 
 The server is configured to listen on the address `127.0.0.1:8443` and act as an HTTP/3 file server.


### PR DESCRIPTION
After installing **tquic** and building the example tools with:

```bash
cargo build --release --all
```

running the QUIC server as documented:

```bash
./tquic_server -c cert.crt -k cert.key -l 127.0.0.1:8443
```

Leads to the following error:

```
TlsFail("use certificate chain file(\"cert.crt\") failed")
```

## Cause

The generated binaries are placed in:

```
./target/release/
```

However, the example certificates (`cert.crt` and `cert.key`) are located in:

```
./src/tls/testdata/
```

When running the binary from a different directory, the relative paths `cert.crt` and `cert.key` cannot be resolved, which causes TLS initialization to fail.

## Proposed Fix

Update the documentation to use the correct certificate paths:

```bash
./tquic_server -c ../../src/tls/testdata/cert.crt -k ../../src/tls/testdata/cert.key -l 127.0.0.1:8443 
```

Alternatively, instruct users to run the binary from the project root directory or copy the certificates into the same directory as the executable.

This ensures the server can properly locate and load the TLS certificate and private key.